### PR TITLE
Added __truediv__ for Python 3

### DIFF
--- a/mgl2d/math/vector2.py
+++ b/mgl2d/math/vector2.py
@@ -48,6 +48,8 @@ class Vector2(object):
     def __div__(self, value):
         return Vector2(self.x / value, self.y / value)
 
+    __truediv__ = __div__
+
     def __mul__(self, value):
         return Vector2(self.x * value, self.y * value)
 


### PR DESCRIPTION
In Python 3, there's no `__div__` anymore but `__truediv__` and `__floordiv__` (aka integer division).
This commit just sets `__truediv__` to `__div__`, so both versions should be supported.